### PR TITLE
rustsec-website-gen: Initial web site generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+Cargo.lock
 .sass-cache
 _site
+target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: rust
+cache: cargo
+
+script: cargo run -p rustsec-website-gen # check the generator succeeds
+
+branches:
+  only:
+    - master
+
+rust:
+  - stable
+
+notifications:
+  irc: 'irc.mozilla.org#rustsec'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["rustsec-website-gen"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # rustsec.org
 
 The https://rustsec.org web site
+
+## Site Generator
+
+To regenerate the web site using the latest advisories from the `advisory-db`,
+run the following command (assuming you have Rust installed):
+
+```
+$ cargo run -p rustsec-website-gen
+```

--- a/_posts/2016-05-09-RUSTSEC-2016-0002.md
+++ b/_posts/2016-05-09-RUSTSEC-2016-0002.md
@@ -1,8 +1,8 @@
 ---
 title:       "RUSTSEC-2016-0002: hyper: HTTPS MitM vulnerability due to lack of hostname verification"
-description: "When used on Windows platforms"
+description: "When used on Windows platforms, all versions of Hyper prior to 0.9.4 did not perform hostname verification when making HTTPS requests. This allows an attacker to perform MitM attacks by preventing any valid CAissued certificate, even if theres a hostname mismatch. The problem was addressed by leveraging rustopenssls builtin support for hostname verification."
 date:        2016-05-09
-tags:        hyper
+tags:        hyper, ssl, mitm
 permalink:   /advisories/RUSTSEC-2016-0002:output_ext
 ---
 
@@ -17,16 +17,11 @@ CA-issued certificate, even if there's a hostname mismatch.
 The problem was addressed by leveraging rust-openssl's built-in support for
 hostname verification.
 
-
-
 ### More Info
 
-<a href="https://github.com/hyperium/hyper/blob/master/CHANGELOG.md#v094-2016-05-09">https://github.com/hyperium/hyper/blob/master/CHANGELOG.md#v094-2016-05-09</a>
-
+<https://github.com/hyperium/hyper/blob/master/CHANGELOG.md#v094-2016-05-09>
 
 ### Patched Versions
 
-
-* `>= 0.9.4`
-
+- `&gt;= 0.9.4`
 

--- a/_posts/2016-11-05-RUSTSEC-2016-0001.md
+++ b/_posts/2016-11-05-RUSTSEC-2016-0001.md
@@ -1,8 +1,8 @@
 ---
 title:       "RUSTSEC-2016-0001: openssl: SSL/TLS MitM vulnerability due to insecure defaults"
-description: "All versions of rust"
+description: "All versions of rustopenssl prior to 0.9.0 contained numerous insecure defaults including offbydefault certificate verification and no API to perform hostname verification. Unless configured correctly by a developer, these defaults could allow an attacker to perform maninthemiddle attacks. The problem was addressed in newer versions by enabling certificate verification by default and exposing APIs to perform hostname verification. Use the SslConnector and SslAcceptor types to take advantage of these new features as opposed to the lowerlevel SslContext type."
 date:        2016-11-05
-tags:        openssl
+tags:        openssl, ssl, mitm
 permalink:   /advisories/RUSTSEC-2016-0001:output_ext
 ---
 
@@ -20,16 +20,11 @@ by default and exposing APIs to perform hostname verification. Use the
 `SslConnector` and `SslAcceptor` types to take advantage of these new features
 (as opposed to the lower-level `SslContext` type).
 
-
-
 ### More Info
 
-<a href="https://github.com/sfackler/rust-openssl/releases/tag/v0.9.0">https://github.com/sfackler/rust-openssl/releases/tag/v0.9.0</a>
-
+<https://github.com/sfackler/rust-openssl/releases/tag/v0.9.0>
 
 ### Patched Versions
 
-
-* `>= 0.9.0`
-
+- `&gt;= 0.9.0`
 

--- a/_posts/2017-01-23-RUSTSEC-2017-0002.md
+++ b/_posts/2017-01-23-RUSTSEC-2017-0002.md
@@ -1,6 +1,6 @@
 ---
 title:       "RUSTSEC-2017-0002: hyper: headers containing newline characters can split messages"
-description: "Serializing of headers to the socket did not filter the values for newline bytes"
+description: "Serializing of headers to the socket did not filter the values for newline bytes  or , which allowed for header values to split a request or response. People would not likely include newlines in the headers in their own applications, so the way for most people to exploit this is if an application constructs headers based on unsanitized user input. This issue was fixed by replacing all newline characters with a space during serialization of a header value."
 date:        2017-01-23
 tags:        hyper
 permalink:   /advisories/RUSTSEC-2017-0002:output_ext
@@ -17,18 +17,12 @@ is if an application constructs headers based on unsanitized user input.
 This issue was fixed by replacing all newline characters with a space during serialization of
 a header value.
 
-
-
 ### More Info
 
-<a href="https://github.com/hyperium/hyper/wiki/Security-001">https://github.com/hyperium/hyper/wiki/Security-001</a>
-
+<https://github.com/hyperium/hyper/wiki/Security-001>
 
 ### Patched Versions
 
-
-* `>= 0.10.2`
-
-* `< 0.10.0, >= 0.9.18`
-
+- `&gt;= 0.10.2`
+- `&lt; 0.10.0, &gt;= 0.9.18`
 

--- a/_posts/2017-01-26-RUSTSEC-2017-0001.md
+++ b/_posts/2017-01-26-RUSTSEC-2017-0001.md
@@ -1,8 +1,8 @@
 ---
 title:       "RUSTSEC-2017-0001: sodiumoxide: scalarmult() vulnerable to degenerate public keys"
-description: "The"
+description: "The scalarmult function included in previous versions of this crate accepted allzero public keys, for which the resulting DiffieHellman shared secret will always be zero regardless of the private key used. This issue was fixed by checking for this class of keys and rejecting them if they are used."
 date:        2017-01-26
-tags:        sodiumoxide
+tags:        sodiumoxide, cryptography
 permalink:   /advisories/RUSTSEC-2017-0001:output_ext
 ---
 
@@ -15,16 +15,11 @@ secret will always be zero regardless of the private key used.
 This issue was fixed by checking for this class of keys and rejecting them
 if they are used.
 
-
-
 ### More Info
 
-<a href="https://github.com/dnaq/sodiumoxide/issues/154">https://github.com/dnaq/sodiumoxide/issues/154</a>
-
+<https://github.com/dnaq/sodiumoxide/issues/154>
 
 ### Patched Versions
 
-
-* `>= 0.0.14`
-
+- `&gt;= 0.0.14`
 

--- a/_posts/2017-03-15-RUSTSEC-2017-0003.md
+++ b/_posts/2017-03-15-RUSTSEC-2017-0003.md
@@ -1,8 +1,8 @@
 ---
 title:       "RUSTSEC-2017-0003: security-framework: Hostname verification skipped when custom root certs used"
-description: "If custom root certificates were registered with a"
+description: "If custom root certificates were registered with a ClientBuilder, the hostname of the target server would not be validated against its presented leaf certificate. This issue was fixed by properly configuring the trust evaluation logic to perform that check."
 date:        2017-03-15
-tags:        security-framework
+tags:        security-framework, mitm
 permalink:   /advisories/RUSTSEC-2017-0003:output_ext
 ---
 
@@ -15,16 +15,11 @@ certificate.
 This issue was fixed by properly configuring the trust evaluation logic to
 perform that check.
 
-
-
 ### More Info
 
-<a href="https://github.com/sfackler/rust-security-framework/pull/27">https://github.com/sfackler/rust-security-framework/pull/27</a>
-
+<https://github.com/sfackler/rust-security-framework/pull/27>
 
 ### Patched Versions
 
-
-* `>= 0.1.12`
-
+- `&gt;= 0.1.12`
 

--- a/_posts/2017-05-03-RUSTSEC-2017-0004.md
+++ b/_posts/2017-05-03-RUSTSEC-2017-0004.md
@@ -1,8 +1,8 @@
 ---
 title:       "RUSTSEC-2017-0004: base64: Integer overflow leads to heap-based buffer overflow in encode_config_buf"
-description: "Affected versions of this crate suffered from an integer overflow bug when"
+description: "Affected versions of this crate suffered from an integer overflow bug when calculating the size of a buffer to use when encoding base64 using the encodeconfigbuf and encodeconfig functions. If the input string was large, this would cause a buffer to be allocated that was too small. Since this function writes to the buffer using unsafe code, it would allow an attacker to write beyond the buffer, causing memory corruption and possibly the execution of arbitrary code. This flaw was corrected by using checked arithmetic to calculate the size of the buffer."
 date:        2017-05-03
-tags:        base64
+tags:        base64, memory-corruption
 permalink:   /advisories/RUSTSEC-2017-0004:output_ext
 ---
 
@@ -19,16 +19,11 @@ and possibly the execution of arbitrary code.
 This flaw was corrected by using checked arithmetic to calculate
 the size of the buffer.
 
-
-
 ### More Info
 
-<a href="https://github.com/alicemaz/rust-base64/commit/24ead980daf11ba563e4fb2516187a56a71ad319">https://github.com/alicemaz/rust-base64/commit/24ead980daf11ba563e4fb2516187a56a71ad319</a>
-
+<https://github.com/alicemaz/rust-base64/commit/24ead980daf11ba563e4fb2516187a56a71ad319>
 
 ### Patched Versions
 
-
-* `>= 0.5.2`
-
+- `&gt;= 0.5.2`
 

--- a/_posts/2017-05-06-RUSTSEC-2017-0005.md
+++ b/_posts/2017-05-06-RUSTSEC-2017-0005.md
@@ -1,8 +1,8 @@
 ---
 title:       "RUSTSEC-2017-0005: cookie: Large cookie Max-Age values can cause a denial of service"
-description: "Affected versions of this crate use the"
+description: "Affected versions of this crate use the time crate and the method Durationseconds to parse the MaxAge duration cookie setting. This method will panic if the value is greater than 2641000 and less than or equal to 264, which can result in denial of service for a client or server. This flaw was corrected by explicitly checking for the MaxAge being in this integer range and clamping the value to the maximum duration value."
 date:        2017-05-06
-tags:        cookie
+tags:        cookie, crash
 permalink:   /advisories/RUSTSEC-2017-0005:output_ext
 ---
 
@@ -16,20 +16,13 @@ will panic if the value is greater than 2^64/1000 and less than or equal to
 This flaw was corrected by explicitly checking for the `Max-Age` being in this
 integer range and clamping the value to the maximum duration value.
 
-
-
 ### More Info
 
-<a href="https://github.com/alexcrichton/cookie-rs/pull/86">https://github.com/alexcrichton/cookie-rs/pull/86</a>
-
+<https://github.com/alexcrichton/cookie-rs/pull/86>
 
 ### Patched Versions
 
-
-* `< 0.6.0`
-
-* `^0.6.2`
-
-* `>= 0.7.6`
-
+- `&lt; 0.6.0`
+- `^0.6.2`
+- `&gt;= 0.7.6`
 

--- a/_posts/2017-10-09-RUSTSEC-2018-0007.md
+++ b/_posts/2017-10-09-RUSTSEC-2018-0007.md
@@ -1,0 +1,28 @@
+---
+title:       "RUSTSEC-2018-0007: trust-dns-proto: Stack overflow when parsing malicious DNS packet"
+description: "Theres a stack overflow leading to a crash when TrustDNSs parses a malicious DNS packet. Affected versions of this crate did not properly handle parsing of DNS message compression RFC1035 section 4.1.4. The parser could be tricked into infinite loop when a compression offset pointed back to the same domain name to be parsed. This allows an attacker to craft a malicious DNS packet which when consumed with TrustDNS could cause stack overflow and crash the affected software. The flaw was corrected by trustdnsproto 0.4.3 and upcoming 0.5.0 release."
+date:        2017-10-09
+tags:        trust-dns-proto, stack-overflow, crash
+permalink:   /advisories/RUSTSEC-2018-0007:output_ext
+---
+
+### Description
+
+There's a stack overflow leading to a crash when Trust-DNS's parses a
+malicious DNS packet.
+
+Affected versions of this crate did not properly handle parsing of DNS message
+compression (RFC1035 section 4.1.4). The parser could be tricked into infinite
+loop when a compression offset pointed back to the same domain name to be
+parsed.
+
+This allows an attacker to craft a malicious DNS packet which when consumed
+with Trust-DNS could cause stack overflow and crash the affected software.
+
+The flaw was corrected by trust-dns-proto 0.4.3 and upcoming 0.5.0 release.
+
+### Patched Versions
+
+- `&gt;= 0.4.3`
+- `&gt;= 0.5.0-alpha.3`
+

--- a/_posts/2018-06-21-RUSTSEC-2018-0001.md
+++ b/_posts/2018-06-21-RUSTSEC-2018-0001.md
@@ -1,8 +1,8 @@
 ---
 title:       "RUSTSEC-2018-0001: untrusted: An integer underflow could lead to panic"
-description: "A mistake in error handling in untrusted before 0"
+description: "A mistake in error handling in untrusted before 0.6.2 could lead to an integer underflow and panic if a user of the crate didnt properly check for errors returned by untrusted. Combination of these two programming errors one in untrusted and another by user of this crate could lead to a panic and maybe a denial of service of affected software. The error in untrusted is fixed in release 0.6.2 released 20180621. Its also advisable that users of untrusted check for their sources for cases where errors returned by untrusted are not handled correctly."
 date:        2018-06-21
-tags:        untrusted
+tags:        untrusted, crash
 permalink:   /advisories/RUSTSEC-2018-0001:output_ext
 ---
 
@@ -20,16 +20,11 @@ The error in untrusted is fixed in release 0.6.2 released 2018-06-21. It's also
 advisable that users of untrusted check for their sources for cases where errors
 returned by untrusted are not handled correctly.
 
-
-
 ### More Info
 
-<a href="https://github.com/briansmith/untrusted/pull/20">https://github.com/briansmith/untrusted/pull/20</a>
-
+<https://github.com/briansmith/untrusted/pull/20>
 
 ### Patched Versions
 
-
-* `>= 0.6.2`
-
+- `&gt;= 0.6.2`
 

--- a/_posts/2018-06-29-RUSTSEC-2018-0002.md
+++ b/_posts/2018-06-29-RUSTSEC-2018-0002.md
@@ -1,8 +1,8 @@
 ---
 title:       "RUSTSEC-2018-0002: tar: Links in archives can overwrite any existing file"
-description: "When unpacking a tarball with the"
+description: "When unpacking a tarball with the unpackinfamily of functions its intended that only files within the specified directory are able to be written. Tarballs with hard links or symlinks, however, can be used to overwrite any file on the filesystem. Tarballs can contain multiple entries for the same file. A tarball which first contains an entry for a hard link or symlink pointing to any file on the filesystem will have the link created, and then afterwards if the same file is listed in the tarball the hard link will be rewritten and any file can be rewritten on the filesystem. This has been fixed in httpsgithub.comalexcrichtontarrspull156 and is published as tar 0.4.16. Thanks to Max Justicz for discovering this and emailing about the issue"
 date:        2018-06-29
-tags:        tar
+tags:        tar, file-overwrite
 permalink:   /advisories/RUSTSEC-2018-0002:output_ext
 ---
 
@@ -19,20 +19,15 @@ filesystem will have the link created, and then afterwards if the same file is
 listed in the tarball the hard link will be rewritten and any file can be
 rewritten on the filesystem.
 
-This has been fixed in <https://github.com/alexcrichton/tar-rs/pull/156> and is
+This has been fixed in https://github.com/alexcrichton/tar-rs/pull/156 and is
 published as `tar` 0.4.16. Thanks to Max Justicz for discovering this and
 emailing about the issue!
 
-
-
 ### More Info
 
-<a href="https://github.com/alexcrichton/tar-rs/pull/156">https://github.com/alexcrichton/tar-rs/pull/156</a>
-
+<https://github.com/alexcrichton/tar-rs/pull/156>
 
 ### Patched Versions
 
-
-* `>= 0.4.16`
-
+- `&gt;= 0.4.16`
 

--- a/_posts/2018-07-19-RUSTSEC-2018-0003.md
+++ b/_posts/2018-07-19-RUSTSEC-2018-0003.md
@@ -1,8 +1,8 @@
 ---
 title:       "RUSTSEC-2018-0003: smallvec: Possible double free during unwinding in SmallVec::insert_many"
-description: "If an iterator passed to"
+description: "If an iterator passed to SmallVecinsertmany panicked in Iteratornext, destructors were run during unwinding while the vector was in an inconsistent state, possibly causing a double free a destructor running on two copies of the same value. This is fixed in smallvec 0.6.3 by ensuring that the vectors length is not updated to include moved items until they have been removed from their original positions. Items may now be leaked if Iteratornext panics, but they will not be dropped more than once. Thank you to Vurich for reporting this bug."
 date:        2018-07-19
-tags:        smallvec
+tags:        smallvec, memory-corruption
 permalink:   /advisories/RUSTSEC-2018-0003:output_ext
 ---
 
@@ -20,28 +20,18 @@ they will not be dropped more than once.
 
 Thank you to @Vurich for reporting this bug.
 
-
-
 ### More Info
 
-<a href="https://github.com/servo/rust-smallvec/issues/96">https://github.com/servo/rust-smallvec/issues/96</a>
-
+<https://github.com/servo/rust-smallvec/issues/96>
 
 ### Patched Versions
 
-
-* `>= 0.6.3`
-
-* `^0.3.4`
-
-* `^0.4.5`
-
-* `^0.5.1`
-
-
+- `&gt;= 0.6.3`
+- `^0.3.4`
+- `^0.4.5`
+- `^0.5.1`
 
 ### Unaffected Versions
 
-
-* `< 0.3.2`
+- `&lt; 0.3.2`
 

--- a/_posts/2018-08-25-RUSTSEC-2018-0004.md
+++ b/_posts/2018-08-25-RUSTSEC-2018-0004.md
@@ -1,8 +1,8 @@
 ---
 title:       "RUSTSEC-2018-0004: claxon: Malicious input could cause uninitialized memory to be exposed"
-description: "Affected versions of Claxon made an invalid assumption about the decode buffer"
+description: "Affected versions of Claxon made an invalid assumption about the decode buffer size being a multiple of a value read from the bitstream. This could cause parts of the decode buffer to not be overwritten. If the decode buffer was newly allocated and uninitialized, this uninitialized memory could be exposed. This allows an attacker to observe parts of the uninitialized memory in the decoded audio stream. The flaw was corrected by checking that the value read from the bistream divides the decode buffer size, and returning a format error if it does not. If an error is returned, the decode buffer is not exposed. Regression tests and an additional fuzzer have been added to prevent similar flaws in the future."
 date:        2018-08-25
-tags:        claxon
+tags:        claxon, uninitialized-memory
 permalink:   /advisories/RUSTSEC-2018-0004:output_ext
 ---
 
@@ -21,18 +21,12 @@ the decode buffer size, and returning a format error if it does not. If an error
 is returned, the decode buffer is not exposed. Regression tests and an
 additional fuzzer have been added to prevent similar flaws in the future.
 
-
-
 ### More Info
 
-<a href="https://github.com/ruuda/claxon/commit/8f28ec275e412dd3af4f3cda460605512faf332c">https://github.com/ruuda/claxon/commit/8f28ec275e412dd3af4f3cda460605512faf332c</a>
-
+<https://github.com/ruuda/claxon/commit/8f28ec275e412dd3af4f3cda460605512faf332c>
 
 ### Patched Versions
 
-
-* `=0.3.2`
-
-* `>= 0.4.1`
-
+- `= 0.3.2`
+- `&gt;= 0.4.1`
 

--- a/_posts/2018-09-17-RUSTSEC-2018-0005.md
+++ b/_posts/2018-09-17-RUSTSEC-2018-0005.md
@@ -1,0 +1,30 @@
+---
+title:       "RUSTSEC-2018-0005: serde_yaml: Uncontrolled recursion leads to abort in deserialization"
+description: "Affected versions of this crate did not properly check for recursion while deserializing aliases. This allows an attacker to make a YAML file with an alias referring to itself causing an abort. The flaw was corrected by checking the recursion depth."
+date:        2018-09-17
+tags:        serde_yaml, crash
+permalink:   /advisories/RUSTSEC-2018-0005:output_ext
+---
+
+### Description
+
+Affected versions of this crate did not properly check for recursion
+while deserializing aliases.
+
+This allows an attacker to make a YAML file with an alias referring
+to itself causing an abort.
+
+The flaw was corrected by checking the recursion depth.
+
+### More Info
+
+<https://github.com/dtolnay/serde-yaml/pull/105>
+
+### Patched Versions
+
+- `&gt;= 0.8.4`
+
+### Unaffected Versions
+
+- `&lt; 0.6.0-rc1`
+

--- a/_posts/2018-09-17-RUSTSEC-2018-0006.md
+++ b/_posts/2018-09-17-RUSTSEC-2018-0006.md
@@ -1,0 +1,26 @@
+---
+title:       "RUSTSEC-2018-0006: yaml-rust: Uncontrolled recursion leads to abort in deserialization"
+description: "Affected versions of this crate did not prevent deep recursion while deserializing data structures. This allows an attacker to make a YAML file with deeply nested structures that causes an abort while deserializing it. The flaw was corrected by checking the recursion depth."
+date:        2018-09-17
+tags:        yaml-rust, crash
+permalink:   /advisories/RUSTSEC-2018-0006:output_ext
+---
+
+### Description
+
+Affected versions of this crate did not prevent deep recursion while
+deserializing data structures.
+
+This allows an attacker to make a YAML file with deeply nested structures
+that causes an abort while deserializing it.
+
+The flaw was corrected by checking the recursion depth.
+
+### More Info
+
+<https://github.com/chyh1990/yaml-rust/pull/109>
+
+### Patched Versions
+
+- `&gt;= 0.4.1`
+

--- a/advisory.md.hbs
+++ b/advisory.md.hbs
@@ -1,0 +1,32 @@
+---
+title:       "{{id}}: {{package}}: {{title}}"
+description: "{{summary}}"
+date:        {{date}}
+tags:        {{tags}}
+permalink:   /advisories/{{id}}:output_ext
+---
+
+### Description
+
+{{description}}
+
+{{#if url ~}}
+### More Info
+
+<{{url}}>
+
+{{/if~}}
+
+### Patched Versions
+
+{{#each patched_versions ~}}
+- `{{this}}`
+{{/each~}}
+
+{{#if unaffected_versions}}
+### Unaffected Versions
+
+{{#each unaffected_versions ~}}
+- `{{this}}`
+{{/each ~}}
+{{/if ~}}

--- a/rustsec-website-gen/Cargo.toml
+++ b/rustsec-website-gen/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rustsec-website-gen"
+version = "0.1.0"
+authors = ["Tony Arcieri <bascule@gmail.com>"]
+publish = false
+
+[dependencies]
+handlebars = "1"
+rustsec = "0.9"
+serde = "1"
+serde_derive = "1"

--- a/rustsec-website-gen/src/main.rs
+++ b/rustsec-website-gen/src/main.rs
@@ -1,0 +1,118 @@
+extern crate handlebars;
+extern crate rustsec;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+
+use handlebars::Handlebars;
+use rustsec::{Advisory, AdvisoryDatabase};
+use std::{fs::File, io::{Read, Write}, path::PathBuf};
+
+/// Handlebars template for advisory markdown files
+pub const ADVISORY_TEMPLATE: &str = "advisory.md.hbs";
+
+/// Parameters to pass to the `advisory.md.hbs` Handlebars template
+#[derive(Debug, Serialize)]
+pub struct AdvisoryParams {
+    /// Advisory ID (i.e. `RUSTSEC-20YY-NNNN`)
+    pub id: String,
+
+    /// Package name (i.e. crate name)
+    pub package: String,
+
+    /// Title of advisory
+    pub title: String,
+
+    /// One-liner summary of the advisory
+    pub summary: String,
+
+    /// Full description
+    pub description: String,
+
+    /// Advisory date
+    pub date: String,
+
+    /// Tags to associate with this advisory
+    pub tags: String,
+
+    /// URL for more information
+    pub url: Option<String>,
+
+    /// Patched versions
+    pub patched_versions: Vec<String>,
+
+    /// Unaffected versions
+    pub unaffected_versions: Option<Vec<String>>,
+}
+
+impl<'a> From<&'a Advisory> for AdvisoryParams {
+    fn from(advisory: &Advisory) -> AdvisoryParams {
+        let patched_versions = advisory
+            .patched_versions
+            .iter()
+            .map(|req| req.to_string())
+            .collect();
+
+        let unaffected_versions = if advisory.unaffected_versions.is_empty() {
+            None
+        } else {
+            Some(
+                advisory
+                    .unaffected_versions
+                    .iter()
+                    .map(|req| req.to_string())
+                    .collect(),
+            )
+        };
+
+        let mut summary = advisory.description.replace('\n', " ").replace("  ", " ");
+        summary.retain(|c| match c {
+            'A'...'Z' | 'a'...'z' | '0'...'9' | ' ' | ',' | '.' => true,
+            _ => false,
+        });
+
+        let mut tags = vec![advisory.package.to_string()];
+        tags.extend(advisory.keywords.iter().map(|kw| kw.as_str().to_owned()));
+
+        AdvisoryParams {
+            id: advisory.id.to_string(),
+            package: advisory.package.to_string(),
+            title: advisory.title.clone(),
+            summary: summary.trim().to_owned(),
+            description: advisory.description.trim().to_owned(),
+            date: advisory.date.as_str().to_owned(),
+            tags: tags.join(", "),
+            url: advisory.url.clone(),
+            patched_versions,
+            unaffected_versions,
+        }
+    }
+}
+
+fn main() {
+    let mut template_file = File::open(ADVISORY_TEMPLATE).unwrap();
+    let mut template = String::new();
+    template_file.read_to_string(&mut template).unwrap();
+
+    let mut handlebars = Handlebars::new();
+    handlebars
+        .register_template_string(ADVISORY_TEMPLATE, template)
+        .unwrap();
+
+    let advisories: Vec<AdvisoryParams> = AdvisoryDatabase::fetch()
+        .unwrap()
+        .advisories()
+        .map(AdvisoryParams::from)
+        .collect();
+
+    for advisory in &advisories {
+        let output_path = PathBuf::from("_posts").join(format!("{}-{}.md", advisory.date, advisory.id));
+        println!("*** Rendering {}", output_path.display());
+
+        let rendered = handlebars.render(ADVISORY_TEMPLATE, advisory).unwrap();
+        let mut output_file = File::create(output_path).unwrap();
+        output_file.write_all(rendered.as_bytes()).unwrap();
+    }
+
+    println!("Done!");
+}


### PR DESCRIPTION
Downloads the latest advisory DB using the `rustsec` crate and renders advisory posts as markdown from an Handlebars template.

Also checked in is the generated result.