### PR TITLE
Fix RUSTSEC-2018-0007

### DIFF
--- a/_posts/2018-10-09-RUSTSEC-2018-0007.md
+++ b/_posts/2018-10-09-RUSTSEC-2018-0007.md
@@ -1,7 +1,7 @@
 ---
 title:       "RUSTSEC-2018-0007: trust-dns-proto: Stack overflow when parsing malicious DNS packet"
 description: "Theres a stack overflow leading to a crash when TrustDNSs parses a malicious DNS packet. Affected versions of this crate did not properly handle parsing of DNS message compression RFC1035 section 4.1.4. The parser could be tricked into infinite loop when a compression offset pointed back to the same domain name to be parsed. This allows an attacker to craft a malicious DNS packet which when consumed with TrustDNS could cause stack overflow and crash the affected software. The flaw was corrected by trustdnsproto 0.4.3 and upcoming 0.5.0 release."
-date:        2017-10-09
+date:        2018-10-09
 tags:        trust-dns-proto, stack-overflow, crash
 permalink:   /advisories/RUSTSEC-2018-0007:output_ext
 ---


### PR DESCRIPTION
The original vulnerability was accidentally dated 2017 instead of 2018