### PR TITLE
Do not perform HTML escaping on description HTML

### DIFF
--- a/rustsec-website-gen/templates/advisory.md.hbs
+++ b/rustsec-website-gen/templates/advisory.md.hbs
@@ -8,12 +8,12 @@ permalink:   /advisories/{{id}}:output_ext
 
 ### Description
 
-{{description}}
+{{{description}}}
 
 {{#if url ~}}
 ### More Info
 
-<{{url}}>
+<{{{url}}}>
 
 {{/if~}}
 
@@ -21,7 +21,7 @@ permalink:   /advisories/{{id}}:output_ext
 
 {{#if patched_versions~}}
 {{#each patched_versions ~}}
-- `{{this}}`
+- `{{{this}}}`
 {{/each~}}
 {{~else~}}
 - None!
@@ -31,6 +31,6 @@ permalink:   /advisories/{{id}}:output_ext
 ### Unaffected Versions
 
 {{#each unaffected_versions ~}}
-- `{{this}}`
+- `{{{this}}}`
 {{/each ~}}
 {{/if ~}}


### PR DESCRIPTION
Since the description is already being converted into HTML by the markdown processor,
we don't need to do the conversion ourselves.

Fixes https://github.com/RustSec/advisory-db/issues/130

Note that this is, honestly, kind of a hack. What's really needed here is
Markdown-specific escaping logic, or, better yet, remove Markdown from the processing
pipeline entirely and just generate HTML from TOML.